### PR TITLE
Add future transaction option and colors (fixed)

### DIFF
--- a/PerDiem/PerDiem.xcodeproj/project.pbxproj
+++ b/PerDiem/PerDiem.xcodeproj/project.pbxproj
@@ -41,6 +41,7 @@
 		8E9DA2C91BF561690016ECC2 /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 8E9DA2C81BF561690016ECC2 /* AppDelegate.m */; };
 		8E9DA2D11BF561690016ECC2 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 8E9DA2D01BF561690016ECC2 /* Assets.xcassets */; };
 		8E9DA2D41BF561690016ECC2 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 8E9DA2D21BF561690016ECC2 /* LaunchScreen.storyboard */; };
+		8EC0E14C1C06DEEC0004207B /* UIColor+PerDiem.m in Sources */ = {isa = PBXBuildFile; fileRef = 8EC0E14B1C06DEEC0004207B /* UIColor+PerDiem.m */; };
 		BF6D073E1C010E5A00B61276 /* TransactionList.m in Sources */ = {isa = PBXBuildFile; fileRef = BF6D073D1C010E5A00B61276 /* TransactionList.m */; };
 		BF6D07411C01332D00B61276 /* TransactionFormViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = BF6D07401C01332D00B61276 /* TransactionFormViewController.m */; };
 		BF8ADB5C1C04CBF500AEEBFE /* BudgetCell.m in Sources */ = {isa = PBXBuildFile; fileRef = BF8ADB5A1C04CBF500AEEBFE /* BudgetCell.m */; };
@@ -112,6 +113,8 @@
 		8E9DA2D01BF561690016ECC2 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		8E9DA2D31BF561690016ECC2 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		8E9DA2D51BF561690016ECC2 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		8EC0E14A1C06DEEC0004207B /* UIColor+PerDiem.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "UIColor+PerDiem.h"; path = "Categories/UIColor+PerDiem.h"; sourceTree = "<group>"; };
+		8EC0E14B1C06DEEC0004207B /* UIColor+PerDiem.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "UIColor+PerDiem.m"; path = "Categories/UIColor+PerDiem.m"; sourceTree = "<group>"; };
 		BF6D073C1C010E5A00B61276 /* TransactionList.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = TransactionList.h; path = models/TransactionList.h; sourceTree = "<group>"; };
 		BF6D073D1C010E5A00B61276 /* TransactionList.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = TransactionList.m; path = models/TransactionList.m; sourceTree = "<group>"; };
 		BF6D073F1C01332D00B61276 /* TransactionFormViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = TransactionFormViewController.h; path = Controllers/TransactionFormViewController.h; sourceTree = "<group>"; };
@@ -233,6 +236,7 @@
 		8E9DA2C31BF561690016ECC2 /* PerDiem */ = {
 			isa = PBXGroup;
 			children = (
+				8EC0E1491C06DED70004207B /* Categories */,
 				4AF678251C025F0500DFB75E /* Helpers */,
 				BFE4324F1C00338F00809F7E /* Controllers */,
 				8E42F4561C02427300AE2E37 /* Views */,
@@ -253,6 +257,15 @@
 				8E9DA2C51BF561690016ECC2 /* main.m */,
 			);
 			name = "Supporting Files";
+			sourceTree = "<group>";
+		};
+		8EC0E1491C06DED70004207B /* Categories */ = {
+			isa = PBXGroup;
+			children = (
+				8EC0E14A1C06DEEC0004207B /* UIColor+PerDiem.h */,
+				8EC0E14B1C06DEEC0004207B /* UIColor+PerDiem.m */,
+			);
+			name = Categories;
 			sourceTree = "<group>";
 		};
 		BF8ADB621C05711100AEEBFE /* Forms */ = {
@@ -459,6 +472,7 @@
 				4AA1AB651C01559500BF3604 /* CalendarSubViewController.m in Sources */,
 				BF8ADB651C05712D00AEEBFE /* BudgetFormViewController.m in Sources */,
 				BF8ADB5C1C04CBF500AEEBFE /* BudgetCell.m in Sources */,
+				8EC0E14C1C06DEEC0004207B /* UIColor+PerDiem.m in Sources */,
 				BFE432591C0039BB00809F7E /* Transaction.m in Sources */,
 				BFE4324E1C0028F800809F7E /* User.m in Sources */,
 				4AEB60EE1C01186800679DAF /* NavigationViewController.m in Sources */,

--- a/PerDiem/PerDiem/Categories/UIColor+PerDiem.h
+++ b/PerDiem/PerDiem/Categories/UIColor+PerDiem.h
@@ -1,0 +1,24 @@
+//
+//  UIColor+PerDiem.h
+//  PerDiem
+//
+//  Created by Chad Jewsbury on 11/24/15.
+//  Copyright © 2015 PerDiem. All rights reserved.
+//
+
+#import <UIKit/UIKit.h>
+
+@interface UIColor (PerDiemColors)
+
++ (UIColor *)darkGreyColor;
++ (UIColor *)darkGreyColorWithAlpha:(CGFloat)alpha;
++ (UIColor *)darkBlueColor;
++ (UIColor *)darkBlueColorWithAlpha:(CGFloat)alpha;
++ (UIColor *)lightBlueColor;
++ (UIColor *)lightBlueColorWithAlpha:(CGFloat)alpha;
++ (UIColor *)lightGreyColor;
++ (UIColor *)lightGreyColorWithAlpha:(CGFloat)alpha;
++ (UIColor *)redHighlightColor;
++ (UIColor *)redHighlightColorWithAlpha:(CGFloat)alpha;
+
+@end

--- a/PerDiem/PerDiem/Categories/UIColor+PerDiem.m
+++ b/PerDiem/PerDiem/Categories/UIColor+PerDiem.m
@@ -1,0 +1,60 @@
+//
+//  UIColor+PerDiem.m
+//  PerDiem
+//
+//  Created by Chad Jewsbury on 11/24/15.
+//  Copyright © 2015 PerDiem. All rights reserved.
+//
+
+#import "UIColor+PerDiem.h"
+
+@implementation UIColor (PerDiemColors)
+
+// Colors from: https://color.adobe.com/Rise-color-theme-3648332/
+// Dark Grey: #2B3A42 [UIColor colorWithRed:0.17 green:0.23 blue:0.26 alpha:1.0];
+// Dark Blue: #3F5765 [UIColor colorWithRed:0.25 green:0.34 blue:0.40 alpha:1.0];
+// Light Blue: #BDD4DE [UIColor colorWithRed:0.74 green:0.83 blue:0.87 alpha:1.0];
+// Light Grey: #EFEFEF [UIColor colorWithRed:0.94 green:0.94 blue:0.94 alpha:1.0];
+// RedHighlight: #E74C3C [UIColor colorWithRed:0.91 green:0.30 blue:0.24 alpha:1.0];
+
+// Dark Grey
++ (UIColor *)darkGreyColorWithAlpha:(CGFloat)alpha {
+    return [UIColor colorWithRed:0.17 green:0.23 blue:0.26 alpha:alpha];
+}
++ (UIColor *)darkGreyColor {
+    return [[self class] darkGreyColorWithAlpha:1];
+}
+
+// Dark Blue
++ (UIColor *)darkBlueColorWithAlpha:(CGFloat)alpha {
+    return [UIColor colorWithRed:0.25 green:0.34 blue:0.40 alpha:alpha];
+}
++ (UIColor *)darkBlueColor {
+    return [[self class] darkBlueColorWithAlpha:1];
+}
+
+// Light Blue
++ (UIColor *)lightBlueColorWithAlpha:(CGFloat)alpha {
+    return [UIColor colorWithRed:0.74 green:0.83 blue:0.87 alpha:alpha];
+}
++ (UIColor *)lightBlueColor {
+    return [[self class] lightBlueColorWithAlpha:1];
+}
+
+// Light Grey
++ (UIColor *)lightGreyColorWithAlpha:(CGFloat)alpha {
+    return [UIColor colorWithRed:0.94 green:0.94 blue:0.94 alpha:alpha];
+}
++ (UIColor *)lightGreyColor {
+    return [[self class] lightGreyColorWithAlpha:1];
+}
+
+// Red Highlight
++ (UIColor *)redHighlightColorWithAlpha:(CGFloat)alpha {
+    return [UIColor colorWithRed:0.91 green:0.30 blue:0.24 alpha:alpha];
+}
++ (UIColor *)redHighlightColor {
+    return [[self class] redHighlightColorWithAlpha:1];
+}
+
+@end

--- a/PerDiem/PerDiem/Controllers/TransactionFormViewController.m
+++ b/PerDiem/PerDiem/Controllers/TransactionFormViewController.m
@@ -17,6 +17,7 @@ NSString *const kAmount = @"amount";
 NSString *const kDate = @"transactionDate";
 NSString *const kDescription = @"description";
 NSString *const kBudget = @"selectorPush";
+NSString *const kFuture = @"future";
 
 
 @interface TransactionFormViewController ()
@@ -101,6 +102,11 @@ NSString *const kBudget = @"selectorPush";
 
     [section addFormRow:row];
 
+    // Future
+    row = [XLFormRowDescriptor formRowDescriptorWithTag:kFuture rowType:XLFormRowDescriptorTypeBooleanSwitch title:@"Future Transaction"];
+    row.required = NO;
+    [section addFormRow: row];
+
     //Description
     row = [XLFormRowDescriptor formRowDescriptorWithTag:kDescription rowType:XLFormRowDescriptorTypeTextView title:@"Description"];
     if (transaction.note) {
@@ -137,6 +143,7 @@ NSString *const kBudget = @"selectorPush";
     }
     self.transaction.note = values[kDescription];
     self.transaction.transactionDate = values[kDate];
+    self.transaction.future = values[kFuture];
     [self.transaction saveInBackground];
 
     [self.navigationController popViewControllerAnimated:YES];

--- a/PerDiem/PerDiem/TransactionCell.m
+++ b/PerDiem/PerDiem/TransactionCell.m
@@ -9,6 +9,7 @@
 #import "TransactionCell.h"
 #import "Budget.h"
 #import "PaymentType.h"
+#import "UIColor+PerDiem.h"
 
 @interface TransactionCell ()
 @property (weak, nonatomic) IBOutlet UILabel *dateLabel;
@@ -36,6 +37,18 @@
     // self.paymentTypeLabel.text = self.transaction.paymentType.name;
     self.summaryLabel.text = self.transaction.summary;
     self.amountLabel.text = [self.amountFormatter stringFromNumber:self.transaction.amount];
+
+    if (self.transaction.future) {
+        [self styleFutureCell];
+    }
+}
+
+- (void)styleFutureCell {
+    self.summaryLabel.font = [UIFont italicSystemFontOfSize:15];
+    self.amountLabel.font = [UIFont italicSystemFontOfSize:15];
+    self.summaryLabel.textColor = [UIColor darkBlueColor];
+    self.amountLabel.textColor = [UIColor darkBlueColor];
+    [self setBackgroundColor:[UIColor lightBlueColorWithAlpha:.3]];
 }
 
 - (NSString *)formatDate:(NSDate *)date {

--- a/PerDiem/PerDiem/models/Transaction.h
+++ b/PerDiem/PerDiem/models/Transaction.h
@@ -24,6 +24,7 @@
 
 @property (nonatomic, strong) NSNumber *amount;
 @property (nonatomic, strong) NSDate *transactionDate;
+@property (nonatomic, assign) BOOL future;
 @property (nonatomic, strong) NSString *summary;
 @property (nonatomic, strong) NSString *note;
 

--- a/PerDiem/PerDiem/models/Transaction.m
+++ b/PerDiem/PerDiem/models/Transaction.m
@@ -13,7 +13,7 @@
 #import "TransactionList.h"
 
 @implementation Transaction
-@dynamic amount, transactionDate, summary, note, user, budget,  paymentType, organization;
+@dynamic amount, transactionDate, summary, future, note, user, budget,  paymentType, organization;
 
 + (void)load {
     [self registerSubclass];


### PR DESCRIPTION
Added checkbox to new transaction form for futures. It sets a BOOL on the backend that is then used to display it differently in the transactions list. We can use it to treat the transactions differently in other instances too.

Also added some basic colors to be used throughout the app. We can change them as needed, but they're centralized in a category and accessible with [UIColor nameOfColor] after importing the UIColor extension.

Had project conflicts with a previous branch. Rebuilt on this branch and should be fine now. 
