### PR TITLE
Ensure to fetch transactions for the entire month when calculating the daily perdiem.

### DIFF
--- a/PerDiem/PerDiem/models/PerDiem.h
+++ b/PerDiem/PerDiem/models/PerDiem.h
@@ -12,6 +12,9 @@
 @interface PerDiem : NSObject
 
 + (void)perDiemsForPeriod:(DTTimePeriod *)period
+          relatedToPeriod:(DTTimePeriod *)relatedPeriod
+               completion:(void (^)(NSArray<PerDiem *>*, NSError *error))completion;
++ (void)perDiemsForPeriod:(DTTimePeriod *)period
                completion:(void (^)(NSArray<PerDiem *>*, NSError *error))completion;
 + (void)perDiemsForDate:(NSDate *)date
              completion:(void (^)(PerDiem *, NSError *error))completion;


### PR DESCRIPTION
My previous PR introduced a bug when PerDiem was fetched for one day only.
This PR adds a param to the base method to pass related period PerDiem needs calculation for.
