### PR TITLE
Prevent perdiem budget to be negative. Correctly calculate percentage.

### DIFF
--- a/PerDiem/PerDiem/Views/PerDiemView.m
+++ b/PerDiem/PerDiem/Views/PerDiemView.m
@@ -58,14 +58,23 @@
     
     self.dayLabel.text = [[self.perDiem.date formattedDateWithFormat:@"ccc d"] uppercaseString];
     
-    NSString *budgetAmountString = [amountFormatter stringFromNumber:self.perDiem.budget];
-    NSString *spentAmountString = [amountFormatter stringFromNumber:self.perDiem.spent];
-    self.spentLabel.text = [NSString stringWithFormat:@"Spent %@ of %@", spentAmountString, budgetAmountString];
+    CGFloat budget = [self.perDiem.budget floatValue];
+    CGFloat spent = [self.perDiem.spent floatValue];
     NSInteger percentage = 0;
-    if (self.perDiem.budget > 0) {
-        percentage = [self.perDiem.spent integerValue] * 100 / [self.perDiem.budget integerValue];
+    if (budget <= 0) {
+        budget = 0;
+        if (spent > 0) {
+            percentage = 100;
+        } else {
+            percentage = 0;
+        }
+    } else {
+        percentage = spent * 100 / budget;
     }
-
+    NSString *budgetAmountString = [amountFormatter stringFromNumber:@(budget)];
+    NSString *spentAmountString = [amountFormatter stringFromNumber:@(spent)];
+    self.spentLabel.text = [NSString stringWithFormat:@"Spent %@ of %@", spentAmountString, budgetAmountString];
+    
     if ([self.perDiem.date isLaterThan:[NSDate date]]) {
         for (UIView *view in self.cellUIViews) {
             view.alpha = .6;
@@ -80,8 +89,7 @@
     self.widthConstraint.constant = percentage * (self.frame.size.width / 100);
     [self.progressBarBackgroundView.layer setCornerRadius:5.0f];
     [self.progressBarBackgroundView.layer setMasksToBounds:YES];
-
+    
 }
-
 
 @end


### PR DESCRIPTION
before:
<img width="487" alt="screen shot 2015-12-09 at 9 30 43 pm" src="https://cloud.githubusercontent.com/assets/309515/11707660/3756eb30-9ebc-11e5-881d-a582b68568aa.png">

after:
<img width="487" alt="screen shot 2015-12-09 at 9 31 17 pm" src="https://cloud.githubusercontent.com/assets/309515/11707777/42fb28ba-9ebd-11e5-8035-8c6e67b086b1.png">
